### PR TITLE
Add unlink logics

### DIFF
--- a/components/contents-panel/thumbnail/index.tsx
+++ b/components/contents-panel/thumbnail/index.tsx
@@ -14,6 +14,9 @@ export const Thumbnail: React.FC<ImageProps> = (props) => {
     <div className={styles.container}>
       <a href={link}>
         <img src={thumbData} />
+        <div className={styles.label}>
+          <span>{props.content.filename}</span>
+        </div>
       </a>
     </div>
   );

--- a/components/contents-panel/thumbnail/styles.module.css
+++ b/components/contents-panel/thumbnail/styles.module.css
@@ -1,5 +1,6 @@
 .container {
   display: inline-block;
+  margin-bottom: 10px;
 
   & img {
     margin: 5px;
@@ -12,6 +13,18 @@
 
     &:hover {
       opacity: 0.8;
+    }
+  }
+
+  & .label {
+    text-align: center;
+    margin: 10px 0px;
+
+    & > span {
+      font-size: small;
+      background-color: #e4e4e4;
+      border-radius: 50px;
+      padding: 3px 10px;
     }
   }
 }

--- a/constants/db.ts
+++ b/constants/db.ts
@@ -26,8 +26,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
       \`id\` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
       \`content_id\` int(10) UNSIGNED NOT NULL,
       \`data\` MEDIUMBLOB NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`),
       INDEX \`content_id_index\` (\`content_id\`) 
     );
@@ -39,8 +39,12 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
       \`path\` text NOT NULL,
       \`filename\` text NOT NULL,
       \`file_hash\` CHAR(128) NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`unlink\` BOOL NOT NULL DEFAULT 0,
+      \`last_accessed_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`last_modified_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`last_changed_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`),
       INDEX \`directory_id_index\` (\`directory_id\`),
       INDEX \`file_hash_index\` (\`file_hash\`)
@@ -50,8 +54,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
     CREATE TABLE \`tags\` (
       \`id\` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
       \`tag\` varchar(256) NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`)
     );
   `,
@@ -59,8 +63,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
     CREATE TABLE \`albums\` (
       \`id\` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
       \`name\` varchar(256) NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`)
     );
   `,
@@ -70,8 +74,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
       \`label\` varchar(256) NOT NULL,
       \`path\` varchar(256) NOT NULL UNIQUE,
       \`alias_path\` varchar(256) NOT NULL UNIQUE,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`)
     );
   `,
@@ -79,8 +83,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
     CREATE TABLE \`configs\` (
       \`name\` CHAR(64) NOT NULL,
       \`value\` JSON NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`name\`)
     )`,
   [TABLE_CONTENTS_TAGS]: `
@@ -88,8 +92,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
       \`id\` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
       \`content_id\` int(10) UNSIGNED NOT NULL,
       \`tag_id\` int(10) UNSIGNED NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`),
       UNIQUE KEY \`content_tag_index\` (\`content_id\`,\`tag_id\`)
     );
@@ -99,8 +103,8 @@ export const CREATE_TABLE: { [key in typeof TABLES[number]]: string } = {
       \`id\` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
       \`content_id\` int(10) UNSIGNED NOT NULL,
       \`album_id\` int(10) UNSIGNED NOT NULL,
-      \`created_at\` timestamp NOT NULL DEFAULT current_timestamp(),
-      \`updated_at\` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+      \`created_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3),
+      \`updated_at\` timestamp(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
       PRIMARY KEY (\`id\`),
       UNIQUE KEY \`content_album_index\` (\`content_id\`,\`album_id\`)
     );

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.3",
+    "dayjs": "^1.11.5",
     "fluent-ffmpeg": "^2.1.2",
     "http-server": "^14.1.1",
     "next": "12.2.3",

--- a/pages/api/db/add-directory.ts
+++ b/pages/api/db/add-directory.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import nodePath from 'path';
 import punycode from 'punycode';
 import { mysql, connect } from '../../../utilities/mysql-connect';
-import { startScanner } from '../../../utilities/start-scanner';
+const { startScanner } = require('../../../utilities/scanner-controller');
 
 interface AddDirectoryParams {
   path: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
     const [directoriesResult, contentsResult] = await Promise.all([
       mysql.query('SELECT * FROM directories'),
       mysql.query(
-        'SELECT contents.*, directories.alias_path, thumbnails.data as thumbnail FROM contents LEFT JOIN directories ON contents.directory_id = directories.id LEFT JOIN thumbnails ON contents.id = thumbnails.content_id ORDER BY contents.created_at DESC;'
+        'SELECT contents.*, directories.alias_path, thumbnails.data as thumbnail FROM contents LEFT JOIN directories ON contents.directory_id = directories.id LEFT JOIN thumbnails ON contents.id = thumbnails.content_id WHERE contents.unlink = 0 ORDER BY contents.created_at DESC;'
       ),
     ]);
     const directories = JSON.parse(JSON.stringify(directoriesResult)) as DirectoriesTable[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,11 @@ damerau-levenshtein@^1.0.8:
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
 
+dayjs@^1.11.5:
+  version "1.11.5"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.5.tgz#00e8cc627f231f9499c19b38af49f56dc0ac5e93"
+  integrity sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"


### PR DESCRIPTION
### 概要
- `contents` テーブルに unlink (Tiny INT) を追加
- ディレクトリからファイルを削除時に DB に unlink = 1 のフラグを書き込む
  - 論理削除で一覧から表示されなくなる
  - そのうち batch で物理削除しても良いかも

#### Rename の場合
- unlink 後に add が走る
- 15秒以内（chokidar のポーリングが10秒のため）に add された場合 rename とみなして unlink = 0 を書き込む
 - 同一ファイルが rename されたと判定する条件
   - update_at が15秒以内
   - file_hash が変化なし
   - created_at が変化なし

### おまけ
- デバッグ中分かりづらかったためファイル名の表示を追加
- 
![スクリーンショット 2022-09-14 12 55 38](https://user-images.githubusercontent.com/6761278/190056062-747a95bd-17e6-462e-b59a-6aa114a44eac.png)
