### PR TITLE
Change to also return the collection's contents 

### DIFF
--- a/packages/api-schema/graphql/mutations/content.graphql
+++ b/packages/api-schema/graphql/mutations/content.graphql
@@ -1,0 +1,5 @@
+mutation createContentAsCollection($name: String!, $contentIds: [Int!]) {
+  createCollection(name: $name, contentIds: $contentIds) {
+    id
+  }
+}

--- a/packages/api-schema/graphql/queries/content.graphql
+++ b/packages/api-schema/graphql/queries/content.graphql
@@ -9,3 +9,15 @@ query getContentById($id: Int!) {
     }
   }
 }
+
+query getContents($limit: Int, $offset: Int, $removed: Boolean) {
+  Contents(limit: $limit, offset: $offset, removed: $removed) {
+    id
+    name
+    type
+    file {
+      path
+      filename
+    }
+  }
+}

--- a/packages/api-schema/graphql/queries/content.graphql
+++ b/packages/api-schema/graphql/queries/content.graphql
@@ -7,6 +7,16 @@ query getContentById($id: Int!) {
       path
       filename
     }
+    collection {
+      contents {
+        id
+        name
+        file {
+          path
+          filename
+        }
+      }
+    }
   }
 }
 
@@ -18,6 +28,16 @@ query getContents($limit: Int, $offset: Int, $removed: Boolean) {
     file {
       path
       filename
+    }
+    collection {
+      contents {
+        id
+        name
+        file {
+          path
+          filename
+        }
+      }
     }
   }
 }

--- a/packages/api-schema/graphql/queries/content.graphql
+++ b/packages/api-schema/graphql/queries/content.graphql
@@ -8,6 +8,7 @@ query getContentById($id: Int!) {
       filename
     }
     collection {
+      id
       contents {
         id
         name
@@ -30,6 +31,7 @@ query getContents($limit: Int, $offset: Int, $removed: Boolean) {
       filename
     }
     collection {
+      id
       contents {
         id
         name

--- a/packages/api-schema/graphql/types/album.graphql
+++ b/packages/api-schema/graphql/types/album.graphql
@@ -1,3 +1,8 @@
+type Album {
+  id: Int!
+  lastModifiedAt: DateTime!
+}
+
 type Mutation {
   attachContentToAlbum(albumId: Int!, contentId: Int!): Void
   detachContentFromAlbum(albumId: Int!, contentId: Int!): Void

--- a/packages/api-schema/graphql/types/collection.graphql
+++ b/packages/api-schema/graphql/types/collection.graphql
@@ -1,3 +1,9 @@
+type Collection {
+  id: Int!
+  contents: [Content!]!
+  lastModifiedAt: DateTime!
+}
+
 type Mutation {
   attachContentToCollection(collectionId: Int!, contentId: Int!, insertOrder: Int): Void
   attachContentsToCollection(collectionId: Int!, contentIds: [Int!]!, insertOrder: Int): Void

--- a/packages/api-schema/graphql/types/content.graphql
+++ b/packages/api-schema/graphql/types/content.graphql
@@ -4,25 +4,6 @@ enum ContentType {
   FILE
 }
 
-type Collection {
-  id: Int!
-  contents: [Content!]!
-  lastModifiedAt: DateTime!
-}
-
-type Album {
-  id: Int!
-  lastModifiedAt: DateTime!
-}
-
-type File {
-  id: Int!
-  path: String!
-  filename: String!
-  fileLastAccessedAt: DateTime!
-  fileLastModifiedAt: DateTime!
-}
-
 type Content {
   id: Int!
   name: String!

--- a/packages/api-schema/graphql/types/content.graphql
+++ b/packages/api-schema/graphql/types/content.graphql
@@ -6,6 +6,7 @@ enum ContentType {
 
 type Collection {
   id: Int!
+  contents: [Content!]!
   lastModifiedAt: DateTime!
 }
 

--- a/packages/api-schema/graphql/types/file.graphql
+++ b/packages/api-schema/graphql/types/file.graphql
@@ -1,0 +1,7 @@
+type File {
+  id: Int!
+  path: String!
+  filename: String!
+  fileLastAccessedAt: DateTime!
+  fileLastModifiedAt: DateTime!
+}

--- a/packages/backend/resolvers/content.resolver.ts
+++ b/packages/backend/resolvers/content.resolver.ts
@@ -100,9 +100,7 @@ export const getContentsInCollectionResolver = async (
 export const getContentsInAlbumResolver = async (
   args: QueryContentsInAlbumArgs
 ): Promise<Content[]> => {
-  return (await await getContentsInAlbum(args)).map((albumContent) =>
-    mapContent(albumContent.content)
-  );
+  return (await getContentsInAlbum(args)).map((albumContent) => mapContent(albumContent.content));
 };
 
 export const createContentCollectionResolver = async (

--- a/packages/backend/resolvers/content.resolver.ts
+++ b/packages/backend/resolvers/content.resolver.ts
@@ -10,6 +10,14 @@ import {
   QueryContentsInAlbumArgs,
 } from '@pic-cube/api-schema/graphql/generated/server.type';
 import {
+  Collection as PrismaCollection,
+  Content as PrismaContent,
+  Album as PrismaAlbum,
+  File as PrismaFile,
+  CollectionContent,
+  File,
+} from '@prisma/client';
+import {
   getContentById,
   getContents,
   createContentAsCollection,
@@ -20,18 +28,56 @@ import {
   getContentsInAlbum,
 } from '../services/content.service';
 
-export const geContentResolver = async (args: QueryContentArgs): Promise<Content> => {
-  const content = await getContentById(args);
+type ContentType = PrismaContent & {
+  album?: PrismaAlbum[];
+  file?: PrismaFile[];
+  collection?: CollectionType[];
+};
+
+type CollectionType =
+  | (PrismaCollection & {
+      collectionContents: (CollectionContent & {
+        content: PrismaContent & {
+          file: File[];
+        };
+      })[];
+    })
+  | never;
+
+const mapCollection = (collection: CollectionType | undefined) => {
+  if (!collection) {
+    return;
+  }
+  return {
+    ...collection,
+    contents: collection.collectionContents.map((collectionContent) => {
+      return {
+        id: collectionContent.content.id,
+        name: collectionContent.content.name,
+        type: collectionContent.content.type,
+        removed: collectionContent.content.removed,
+        lastAccessedAt: collectionContent.content.lastAccessedAt,
+      };
+    }),
+  };
+};
+
+const mapContent = (content: ContentType) => {
+  const collection = content.collection?.[0];
   return {
     id: content.id,
     name: content.name,
     type: content.type,
     removed: content.removed,
     lastAccessedAt: content.lastAccessedAt,
-    collection: content.collection[0],
-    album: content.album[0],
-    file: content.file[0],
+    collection: mapCollection(collection),
+    album: content.album?.[0],
+    file: content.file?.[0],
   };
+};
+
+export const geContentResolver = async (args: QueryContentArgs): Promise<Content> => {
+  return mapContent(await getContentById(args));
 };
 
 export const getContentsResolver = async (args: QueryContentsArgs): Promise<Content[]> => {
@@ -40,28 +86,23 @@ export const getContentsResolver = async (args: QueryContentsArgs): Promise<Cont
     offset: args.offset || undefined,
     removed: args.removed === null ? undefined : args.removed,
   });
-  return contents.map((content) => ({
-    id: content.id,
-    name: content.name,
-    type: content.type,
-    removed: content.removed,
-    lastAccessedAt: content.lastAccessedAt,
-    collection: content.collection[0],
-    album: content.album[0],
-    file: content.file[0],
-  }));
+  return contents.map(mapContent);
 };
 
 export const getContentsInCollectionResolver = async (
   args: QueryContentsInCollectionArgs
 ): Promise<Content[]> => {
-  return await getContentsInCollection(args);
+  return (await getContentsInCollection(args)).map((collectionContent) =>
+    mapContent(collectionContent.content)
+  );
 };
 
 export const getContentsInAlbumResolver = async (
   args: QueryContentsInAlbumArgs
 ): Promise<Content[]> => {
-  return await getContentsInAlbum(args);
+  return (await await getContentsInAlbum(args)).map((albumContent) =>
+    mapContent(albumContent.content)
+  );
 };
 
 export const createContentCollectionResolver = async (
@@ -71,40 +112,17 @@ export const createContentCollectionResolver = async (
     name: args.name,
     contentIds: args.contentIds || undefined,
   });
-  return {
-    id: content.id,
-    name: content.name,
-    type: content.type,
-    removed: content.removed,
-    lastAccessedAt: content.lastAccessedAt,
-    collection: content.collection[0],
-  };
+  return mapContent(content);
 };
 
 export const createContentAlbumResolver = async (
   args: MutationCreateAlbumArgs
 ): Promise<Content> => {
-  const content = await createContentAsAlbum(args);
-  return {
-    id: content.id,
-    name: content.name,
-    type: content.type,
-    removed: content.removed,
-    lastAccessedAt: content.lastAccessedAt,
-    album: content.album[0],
-  };
+  return mapContent(await createContentAsAlbum(args));
 };
 
 export const createContentFileResolver = async (args: MutationCreateFileArgs): Promise<Content> => {
-  const content = await createContentAsFile(args);
-  return {
-    id: content.id,
-    name: content.name,
-    type: content.type,
-    removed: content.removed,
-    lastAccessedAt: content.lastAccessedAt,
-    file: content.file[0],
-  };
+  return mapContent(await createContentAsFile(args));
 };
 
 export const removeContentResolver = async (args: MutationRemoveContentArgs): Promise<Content> => {

--- a/packages/backend/services/content.service.ts
+++ b/packages/backend/services/content.service.ts
@@ -27,7 +27,7 @@ export async function getContents(params: GetContentsParams) {
   return await prisma.content.findMany({
     take: params.limit,
     skip: params.offset,
-    where: { removed: params.removed },
+    where: { removed: params.removed, contents: { none: {} } },
     include: {
       collection: {
         include: { collectionContents: { include: { content: { include: { file: true } } } } },

--- a/packages/backend/services/content.service.ts
+++ b/packages/backend/services/content.service.ts
@@ -1,4 +1,3 @@
-import { Content } from '@prisma/client';
 import { prisma } from '../utilities/prisma';
 
 interface GetContentByIdParams {
@@ -8,7 +7,13 @@ interface GetContentByIdParams {
 export async function getContentById(params: GetContentByIdParams) {
   return await prisma.content.findFirstOrThrow({
     where: { id: params.id },
-    include: { collection: true, album: true, file: true },
+    include: {
+      collection: {
+        include: { collectionContents: { include: { content: { include: { file: true } } } } },
+      },
+      album: true,
+      file: true,
+    },
   });
 }
 
@@ -23,7 +28,13 @@ export async function getContents(params: GetContentsParams) {
     take: params.limit,
     skip: params.offset,
     where: { removed: params.removed },
-    include: { collection: true, album: true, file: true },
+    include: {
+      collection: {
+        include: { collectionContents: { include: { content: { include: { file: true } } } } },
+      },
+      album: true,
+      file: true,
+    },
     orderBy: { lastAccessedAt: 'desc' },
   });
 }
@@ -33,20 +44,20 @@ interface GetContentsInCollectionParams {
 }
 
 export async function getContentsInCollection(params: GetContentsInCollectionParams) {
-  const collectionContents = await prisma.collectionContent.findMany({
+  return await prisma.collectionContent.findMany({
     where: { collectionId: params.collectionId },
-    include: { content: { include: { collection: true, album: true, file: true } } },
+    include: {
+      content: {
+        include: {
+          collection: {
+            include: { collectionContents: { include: { content: { include: { file: true } } } } },
+          },
+          album: true,
+          file: true,
+        },
+      },
+    },
   });
-  return collectionContents.map((collectionContent) => ({
-    id: collectionContent.content.id,
-    name: collectionContent.content.name,
-    type: collectionContent.content.type,
-    removed: collectionContent.content.removed,
-    lastAccessedAt: collectionContent.content.lastAccessedAt,
-    collection: collectionContent.content.collection[0],
-    album: collectionContent.content.album[0],
-    file: collectionContent.content.file[0],
-  }));
 }
 
 interface GetContentsInAlbumParams {
@@ -54,20 +65,20 @@ interface GetContentsInAlbumParams {
 }
 
 export async function getContentsInAlbum(params: GetContentsInAlbumParams) {
-  const albumContents = await prisma.albumContent.findMany({
+  return await prisma.albumContent.findMany({
     where: { albumId: params.albumId },
-    include: { content: { include: { collection: true, album: true, file: true } } },
+    include: {
+      content: {
+        include: {
+          collection: {
+            include: { collectionContents: { include: { content: { include: { file: true } } } } },
+          },
+          album: true,
+          file: true,
+        },
+      },
+    },
   });
-  return albumContents.map((albumContent) => ({
-    id: albumContent.content.id,
-    name: albumContent.content.name,
-    type: albumContent.content.type,
-    removed: albumContent.content.removed,
-    lastAccessedAt: albumContent.content.lastAccessedAt,
-    collection: albumContent.content.collection[0],
-    album: albumContent.content.album[0],
-    file: albumContent.content.file[0],
-  }));
 }
 
 interface CreateContentAsCollectionParams {
@@ -86,7 +97,11 @@ export async function createContentAsCollection(params: CreateContentAsCollectio
             create: {},
           },
         },
-        include: { collection: true },
+        include: {
+          collection: {
+            include: { collectionContents: { include: { content: { include: { file: true } } } } },
+          },
+        },
       });
       await prisma.collectionContent.createMany({
         data: (params.contentIds || []).map((contentId, index) => ({


### PR DESCRIPTION
## Overview
フロント実装に向けて以下のAPI周りの変更を行いました。
- contentsの配列をAPIから取得する時、collectionに紐付いたcontent(file)も含めて取得できるようにserviceとresolverを変更
- contentsの配列をAPIから取得する時、collectionに紐付いたcontentsは除外
- フロントで利用するcollection作成のmutationの定義
- リファクタリング
   - album.graphqlの作成とtype Albumの移動
   - file.graphqlの作成とtype Fileの移動
   - collection.graphqlの作成とtype Collectionの移動