### PR TITLE
Fix frontend pm2 config to watch api-schema only

### DIFF
--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -14,6 +14,7 @@ module.exports = {
     },
     {
       name: 'frontend',
+      watch: ['../api-schema'],
       script: 'yarn workspace @pic-cube/frontend dev',
     },
   ],


### PR DESCRIPTION
### Overview
nextjsはそれ自体にwatch機能が含まれているのにも関わらず、pm2がfrontendサーバーをソースの変更のたびに再起動してしまっていたので、api-schemaのみ変更したら再起動するように修正しました。